### PR TITLE
Add /opr rotation skip, preview, and reorder commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ src/
 │   ├── stats.js              # /opr stats logic
 │   ├── players.js            # /opr players list/remove logic
 │   ├── schedule.js           # /opr schedule set/view/clear logic
-│   ├── rotation.js           # /opr rotation setup/view/reset logic
+│   ├── rotation.js           # /opr rotation setup/view/reset/skip/preview/reorder logic
 │   └── setup.js              # /opr setup channel/day/time/view/clear logic
 ├── handlers/
 │   └── interactionHandler.js # Routes interactions to command handlers; top-level error handling
@@ -53,7 +53,7 @@ src/
 ├── utils/
 │   ├── embeds.js             # Discord embed builders (report, stats, reminder, error, info)
 │   ├── stats.js              # computeStats(), topN(), winRate()
-│   └── rotation.js           # generateRotations(), getCurrentMatchup(), getNextMatchup()
+│   └── rotation.js           # generateRotations(), getOrderedMatchups(), getCurrentMatchup(), getNextMatchup(), getPreviewMatchups()
 └── scheduler/
     └── weeklyReminder.js     # Cron job: sends weekly game-night reminder to configured channels
 ```
@@ -83,7 +83,10 @@ All commands live under `/opr`. The full tree:
 ├── rotation
 │   ├── setup                               # Admin — generates matchup rotation
 │   ├── view                                # Everyone
-│   └── reset                               # Admin
+│   ├── preview                             # Everyone — next 4 matchups
+│   ├── reset                               # Admin
+│   ├── skip                                # Admin — advance index without a game report
+│   └── reorder <from> <to>                 # Admin — move a matchup to a new position
 └── setup
     ├── view                                # Everyone
     ├── channel <channel>                   # Admin
@@ -105,7 +108,7 @@ Admin commands require the "Manage Server" Discord permission.
 | `game_participants` | `game_id`, `discord_id`, `discord_name`, `team`, `faction`, `won` | Per-player game participation |
 | `game_schedule` | `guild_id`, `game_date`, `game_type`, `note` | Upcoming scheduled games |
 | `server_config` | `guild_id`, `reminder_channel_id`, `reminder_day`, `reminder_hour`, `last_reminder_date` | Per-guild bot settings |
-| `rotation_state` | `guild_id`, `player_discord_ids[]`, `current_index` | 2v2 rotation state |
+| `rotation_state` | `guild_id`, `player_discord_ids[]`, `current_index`, `matchup_order[]` | 2v2 rotation state |
 
 Guest players use a UUID (not a numeric Discord ID) as their `discord_id`.
 Discord users are displayed as `<@discord_id>` mentions; guests as bold names.
@@ -130,7 +133,7 @@ Discord users are displayed as `<@discord_id>` mentions; guests as bold names.
 - **Embeds:** All user-facing responses are Discord embeds built in `src/utils/embeds.js`. Use `buildErrorEmbed()` for errors and `buildInfoEmbed()` for neutral messages.
 - **Error handling:** Command handlers `try/catch` and return ephemeral error embeds. Uncaught errors are caught in `interactionHandler.js`.
 - **Ephemerals:** Error replies are ephemeral (only the invoking user sees them). Success replies are visible to the channel.
-- **2v2 rotation algorithm:** Fixes the first player on Team 1 and enumerates all C(n-1, n/2-1) partner combinations — guarantees no duplicate matchups. Logic is in `src/utils/rotation.js`.
+- **2v2 rotation algorithm:** Fixes the first player on Team 1 and enumerates all C(n-1, n/2-1) partner combinations — guarantees no duplicate matchups. Logic is in `src/utils/rotation.js`. A custom `matchup_order` integer array (stored in `rotation_state`) can override the natural order; `getOrderedMatchups()` applies it.
 - **Weekly reminder:** `weeklyReminder.js` runs a cron job at the top of every hour, checks `server_config` for matching day/hour, skips if `last_reminder_date` == today, then sends a stats summary embed.
 
 ---

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Discord bot for tracking [One Page Rules](https://onepagerules.com/) game resu
   - [/opr schedule view](#opr-schedule-view)
   - [/opr players list](#opr-players-list)
   - [/opr rotation view](#opr-rotation-view)
+  - [/opr rotation preview](#opr-rotation-preview)
   - [/opr setup view](#opr-setup-view)
 - [Commands — Guild Admins](#commands--guild-admins)
   - [/opr setup channel](#opr-setup-channel)
@@ -34,6 +35,8 @@ A Discord bot for tracking [One Page Rules](https://onepagerules.com/) game resu
   - [/opr players remove](#opr-players-remove)
   - [/opr rotation setup](#opr-rotation-setup)
   - [/opr rotation reset](#opr-rotation-reset)
+  - [/opr rotation skip](#opr-rotation-skip)
+  - [/opr rotation reorder](#opr-rotation-reorder)
   - [/opr register (guest)](#opr-register-guest)
   - [/opr register (Discord user)](#opr-register-discord-user)
 - [Weekly Reminders](#weekly-reminders)
@@ -317,10 +320,26 @@ View the 2v2 team rotation — all matchups, the current one, and what's coming 
 
 **Displays:**
 - All players included in the rotation
-- A numbered list of all matchup pairings (current matchup highlighted)
+- A numbered list of all matchup pairings in the current order (current matchup highlighted)
 - The upcoming matchup for next week
 
 The rotation advances automatically each time a 2v2 game is reported.
+
+---
+
+### /opr rotation preview
+
+Preview the next 4 upcoming matchups from the current position.
+
+```
+/opr rotation preview
+```
+
+**Parameters:** None
+
+**Displays:** Four matchup cards showing the current matchup and the next three after it, each labeled with their rotation position number.
+
+Useful for planning ahead without needing to read the full rotation list.
 
 ---
 
@@ -547,6 +566,51 @@ Use this after all matchups in the current rotation have been played, or any tim
 
 ---
 
+### /opr rotation skip
+
+Skip forward one matchup without requiring a game to be reported.
+
+```
+/opr rotation skip
+```
+
+**Parameters:** None
+
+**Behavior:**
+- Advances `current_index` by one step, wrapping around if at the end of the rotation
+- Responds with the new current matchup
+- Does **not** record a game result — use `/opr report 2v2` for that
+
+Useful when a scheduled game night is cancelled or a matchup needs to be passed over.
+
+---
+
+### /opr rotation reorder
+
+Move a specific matchup to a different position in the rotation order. The change is persistent and affects all future matchups.
+
+```
+/opr rotation reorder from:<position> to:<position>
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `from` | Integer (≥1) | Yes | The current position number of the matchup to move (as shown in `/opr rotation view`) |
+| `to` | Integer (≥1) | Yes | The new position number to move it to |
+
+**Behavior:**
+- The matchup at position `from` is lifted out and inserted at position `to`; all other matchups shift accordingly
+- The currently active matchup remains the same — only its position number may change
+- The updated order is saved to the database and persists across bot restarts
+- Run `/opr rotation setup` to discard all custom ordering and regenerate the natural rotation
+
+**Example:** Move matchup 4 to position 2, pushing the existing matchups 2 and 3 down by one:
+```
+/opr rotation reorder from:4 to:2
+```
+
+---
+
 ### /opr register (guest)
 
 Register a non-Discord (guest) player by name. Useful for in-person players who don't have Discord.
@@ -656,8 +720,11 @@ The bot generates C(5, 2) = 10 unique matchups:
 | `/opr players list` | Everyone |
 | `/opr players remove` | Admins (Manage Server) |
 | `/opr rotation view` | Everyone |
+| `/opr rotation preview` | Everyone |
 | `/opr rotation setup` | Admins (Manage Server) |
 | `/opr rotation reset` | Admins (Manage Server) |
+| `/opr rotation skip` | Admins (Manage Server) |
+| `/opr rotation reorder` | Admins (Manage Server) |
 | `/opr setup view` | Everyone |
 | `/opr setup channel` | Admins (Manage Server) |
 | `/opr setup day` | Admins (Manage Server) |

--- a/schema.sql
+++ b/schema.sql
@@ -77,5 +77,8 @@ CREATE TABLE IF NOT EXISTS rotation_state (
   player_discord_ids  TEXT[]  NOT NULL DEFAULT '{}',
   -- Index into the generated rotation list (points to the NEXT matchup)
   current_index       INTEGER DEFAULT 0,
+  -- Optional custom matchup order: array of original matchup indices (e.g. [0, 2, 1]).
+  -- NULL means use the natural order from generateRotations().
+  matchup_order       INTEGER[],
   updated_at          TIMESTAMPTZ DEFAULT NOW()
 );

--- a/src/commands/opr.js
+++ b/src/commands/opr.js
@@ -140,6 +140,30 @@ module.exports = {
         .setName('reset')
         .setDescription('Reset the rotation back to the first matchup (admin only)')
       )
+      .addSubcommand(sub => sub
+        .setName('skip')
+        .setDescription('Skip forward one matchup without reporting a game (admin only)')
+      )
+      .addSubcommand(sub => sub
+        .setName('preview')
+        .setDescription('Preview the next 4 upcoming matchups')
+      )
+      .addSubcommand(sub => sub
+        .setName('reorder')
+        .setDescription('Move a matchup to a different position in the rotation (admin only)')
+        .addIntegerOption(o => o
+          .setName('from')
+          .setDescription('Current position number of the matchup to move (from /opr rotation view)')
+          .setRequired(true)
+          .setMinValue(1)
+        )
+        .addIntegerOption(o => o
+          .setName('to')
+          .setDescription('New position number to move it to')
+          .setRequired(true)
+          .setMinValue(1)
+        )
+      )
     )
 
     // ── setup ───────────────────────────────────────────────────────────────

--- a/src/commands/rotation.js
+++ b/src/commands/rotation.js
@@ -1,6 +1,13 @@
 const { PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const supabase = require('../database/supabase');
-const { generateRotations, getCurrentMatchup, getNextMatchup, formatMatchup } = require('../utils/rotation');
+const {
+  generateRotations,
+  getOrderedMatchups,
+  getCurrentMatchup,
+  getNextMatchup,
+  getPreviewMatchups,
+  formatMatchup,
+} = require('../utils/rotation');
 const { buildErrorEmbed, buildInfoEmbed, COLORS } = require('../utils/embeds');
 
 /** Build a name map for any guest (non-Discord) player IDs in the list. */
@@ -18,6 +25,21 @@ async function buildGuestNameMap(ids, guildId) {
 /** Format a player ID as a mention for Discord users, or bold name for guests. */
 function fmtPlayer(id, nameMap) {
   return /^\d+$/.test(id) ? `<@${id}>` : `**${nameMap[id] || id}**`;
+}
+
+/** Fetch and validate rotation state. Returns { rotState, error } where error is an embed or null. */
+async function fetchRotationState(guildId) {
+  const { data: rotState, error } = await supabase
+    .from('rotation_state')
+    .select('*')
+    .eq('guild_id', guildId)
+    .maybeSingle();
+
+  if (error) return { rotState: null, fetchError: 'Failed to fetch rotation.' };
+  if (!rotState || rotState.player_discord_ids.length < 4) {
+    return { rotState: null, fetchError: 'No rotation found. Run `/opr rotation setup` first.' };
+  }
+  return { rotState, fetchError: null };
 }
 
 module.exports = {
@@ -72,7 +94,13 @@ module.exports = {
       const { error: upsertErr } = await supabase
         .from('rotation_state')
         .upsert(
-          { guild_id: guildId, player_discord_ids: ids, current_index: 0, updated_at: new Date().toISOString() },
+          {
+            guild_id: guildId,
+            player_discord_ids: ids,
+            current_index: 0,
+            matchup_order: null,
+            updated_at: new Date().toISOString(),
+          },
           { onConflict: 'guild_id' },
         );
 
@@ -119,11 +147,11 @@ module.exports = {
         });
       }
 
-      const ids       = rotState.player_discord_ids;
-      const nameMap   = await buildGuestNameMap(ids, guildId);
-      const rotations = generateRotations(ids);
-      const total     = rotations.length;
-      const current   = rotState.current_index % total;
+      const ids     = rotState.player_discord_ids;
+      const nameMap = await buildGuestNameMap(ids, guildId);
+      const ordered = getOrderedMatchups(rotState);
+      const total   = ordered.length;
+      const current = rotState.current_index % total;
 
       const embed = new EmbedBuilder()
         .setTitle('⚔️ 2v2 Team Rotation')
@@ -133,8 +161,8 @@ module.exports = {
           { name: '👥 Registered Players', value: ids.map(id => fmtPlayer(id, nameMap)).join(', ') },
         );
 
-      // Show all matchups, highlighting the current one
-      const lines = rotations.map(([t1, t2], i) => {
+      // Show all matchups in the (possibly custom) order, highlighting current
+      const lines = ordered.map(([t1, t2], i) => {
         const t1str = t1.map(id => fmtPlayer(id, nameMap)).join(' & ');
         const t2str = t2.map(id => fmtPlayer(id, nameMap)).join(' & ');
         const arrow = i === current ? ' ← **current**' : '';
@@ -169,14 +197,9 @@ module.exports = {
 
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-      const { data: rotState, error: fetchErr } = await supabase
-        .from('rotation_state')
-        .select('*')
-        .eq('guild_id', guildId)
-        .maybeSingle();
-
-      if (fetchErr || !rotState) {
-        return interaction.editReply({ embeds: [buildErrorEmbed('No rotation found. Run `/opr rotation setup` first.')] });
+      const { rotState, fetchError } = await fetchRotationState(guildId);
+      if (fetchError) {
+        return interaction.editReply({ embeds: [buildErrorEmbed(fetchError)] });
       }
 
       const { error: updateErr } = await supabase
@@ -188,18 +211,198 @@ module.exports = {
         return interaction.editReply({ embeds: [buildErrorEmbed('Failed to reset rotation.')] });
       }
 
-      const ids      = rotState.player_discord_ids;
-      const nameMap  = await buildGuestNameMap(ids, guildId);
-      const rotations = generateRotations(ids);
-      const [t1, t2]  = rotations[0];
+      const ids     = rotState.player_discord_ids;
+      const nameMap = await buildGuestNameMap(ids, guildId);
+      const ordered = getOrderedMatchups(rotState);
+      const [t1, t2] = ordered[0];
 
       return interaction.editReply({
         embeds: [buildInfoEmbed(
           '🔄 Rotation Reset',
-          `Rotation has been reset to matchup 1 of ${rotations.length}.\n\n${formatMatchup(t1, t2, nameMap)}`,
+          `Rotation has been reset to matchup 1 of ${ordered.length}.\n\n${formatMatchup(t1, t2, nameMap)}`,
           COLORS.warning,
         )],
       });
+    }
+
+    // ── skip ───────────────────────────────────────────────────────────────
+    if (sub === 'skip') {
+      if (!interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)) {
+        return interaction.reply({
+          embeds: [buildErrorEmbed('You need the **Manage Server** permission to skip the rotation.')],
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const { rotState, fetchError } = await fetchRotationState(guildId);
+      if (fetchError) {
+        return interaction.editReply({ embeds: [buildErrorEmbed(fetchError)] });
+      }
+
+      const ids     = rotState.player_discord_ids;
+      const nameMap = await buildGuestNameMap(ids, guildId);
+      const ordered = getOrderedMatchups(rotState);
+      const total   = ordered.length;
+      const newIndex = (rotState.current_index + 1) % total;
+
+      const { error: updateErr } = await supabase
+        .from('rotation_state')
+        .update({ current_index: newIndex, updated_at: new Date().toISOString() })
+        .eq('guild_id', guildId);
+
+      if (updateErr) {
+        return interaction.editReply({ embeds: [buildErrorEmbed('Failed to skip rotation.')] });
+      }
+
+      const [t1, t2] = ordered[newIndex];
+
+      return interaction.editReply({
+        embeds: [buildInfoEmbed(
+          '⏭️ Rotation Skipped',
+          `Skipped to matchup **${newIndex + 1}** of ${total}.\n\n${formatMatchup(t1, t2, nameMap)}`,
+          COLORS.warning,
+        )],
+      });
+    }
+
+    // ── preview ────────────────────────────────────────────────────────────
+    if (sub === 'preview') {
+      await interaction.deferReply();
+
+      const { data: rotState, error } = await supabase
+        .from('rotation_state')
+        .select('*')
+        .eq('guild_id', guildId)
+        .maybeSingle();
+
+      if (error) {
+        return interaction.editReply({ embeds: [buildErrorEmbed('Failed to fetch rotation.')] });
+      }
+
+      if (!rotState || rotState.player_discord_ids.length < 4) {
+        return interaction.editReply({
+          embeds: [buildInfoEmbed(
+            '⚔️ No Rotation Set Up',
+            'No 2v2 rotation is configured yet.\nAn admin can run `/opr rotation setup` after all players have `/opr register`\'d.',
+          )],
+        });
+      }
+
+      const ids     = rotState.player_discord_ids;
+      const nameMap = await buildGuestNameMap(ids, guildId);
+      const ordered = getOrderedMatchups(rotState);
+      const total   = ordered.length;
+      const preview = getPreviewMatchups(rotState, Math.min(4, total));
+
+      const embed = new EmbedBuilder()
+        .setTitle('🔮 Upcoming Matchup Preview')
+        .setColor(COLORS.info)
+        .setTimestamp();
+
+      const labels = ['⚔️ Current Matchup', '⏭️ Next Matchup', '⏭️ Matchup +2', '⏭️ Matchup +3'];
+      preview.forEach(({ matchup, position }, i) => {
+        const [t1, t2] = matchup;
+        embed.addFields({
+          name: `${labels[i]} (Rotation ${position})`,
+          value: formatMatchup(t1, t2, nameMap),
+        });
+      });
+
+      embed.setFooter({ text: `${total} total matchups in rotation` });
+
+      return interaction.editReply({ embeds: [embed] });
+    }
+
+    // ── reorder ────────────────────────────────────────────────────────────
+    if (sub === 'reorder') {
+      if (!interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)) {
+        return interaction.reply({
+          embeds: [buildErrorEmbed('You need the **Manage Server** permission to reorder the rotation.')],
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const fromPos = interaction.options.getInteger('from'); // 1-indexed
+      const toPos   = interaction.options.getInteger('to');   // 1-indexed
+
+      const { rotState, fetchError } = await fetchRotationState(guildId);
+      if (fetchError) {
+        return interaction.editReply({ embeds: [buildErrorEmbed(fetchError)] });
+      }
+
+      const ids     = rotState.player_discord_ids;
+      const nameMap = await buildGuestNameMap(ids, guildId);
+      const baseRotations = generateRotations(ids);
+      const total = baseRotations.length;
+
+      if (fromPos < 1 || fromPos > total) {
+        return interaction.editReply({
+          embeds: [buildErrorEmbed(`**from** must be between 1 and ${total}.`)],
+        });
+      }
+      if (toPos < 1 || toPos > total) {
+        return interaction.editReply({
+          embeds: [buildErrorEmbed(`**to** must be between 1 and ${total}.`)],
+        });
+      }
+      if (fromPos === toPos) {
+        return interaction.editReply({
+          embeds: [buildErrorEmbed('**from** and **to** cannot be the same position.')],
+        });
+      }
+
+      // Build the current order array (indices into baseRotations)
+      const order = rotState.matchup_order && rotState.matchup_order.length === total
+        ? [...rotState.matchup_order]
+        : Array.from({ length: total }, (_, i) => i);
+
+      // Track which base-rotation index the current matchup corresponds to
+      const currentBaseIdx = order[rotState.current_index % total];
+
+      // Move the item from fromPos-1 to toPos-1
+      const [moved] = order.splice(fromPos - 1, 1);
+      order.splice(toPos - 1, 0, moved);
+
+      // Update current_index so the same matchup remains "current"
+      const newCurrentIndex = order.indexOf(currentBaseIdx);
+
+      const { error: updateErr } = await supabase
+        .from('rotation_state')
+        .update({
+          matchup_order: order,
+          current_index: newCurrentIndex,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('guild_id', guildId);
+
+      if (updateErr) {
+        return interaction.editReply({ embeds: [buildErrorEmbed('Failed to reorder rotation.')] });
+      }
+
+      // Build a preview of the updated sequence
+      const lines = order.map((baseIdx, i) => {
+        const [t1, t2] = baseRotations[baseIdx];
+        const t1str = t1.map(id => fmtPlayer(id, nameMap)).join(' & ');
+        const t2str = t2.map(id => fmtPlayer(id, nameMap)).join(' & ');
+        const arrow = i === newCurrentIndex ? ' ← **current**' : '';
+        return `**${i + 1}.** ${t1str} vs ${t2str}${arrow}`;
+      });
+
+      const embed = new EmbedBuilder()
+        .setTitle('🔀 Rotation Reordered')
+        .setColor(COLORS.success)
+        .setTimestamp()
+        .addFields({
+          name: `🔄 Updated Matchup Order (${total} total)`,
+          value: lines.join('\n'),
+        })
+        .setFooter({ text: 'This order will be followed for all future matchups' });
+
+      return interaction.editReply({ embeds: [embed] });
     }
   },
 };

--- a/src/utils/rotation.js
+++ b/src/utils/rotation.js
@@ -38,15 +38,27 @@ function generateRotations(players) {
 }
 
 /**
+ * Return the matchups in the custom order defined by `matchup_order`, or
+ * in the natural generated order if no custom order is set.
+ * @param {object} rotationState - Row from the rotation_state table
+ * @returns {[string[], string[]][]}
+ */
+function getOrderedMatchups(rotationState) {
+  const rotations = generateRotations(rotationState.player_discord_ids);
+  const { matchup_order } = rotationState;
+  if (!matchup_order || matchup_order.length === 0) return rotations;
+  return matchup_order.map(i => rotations[i]);
+}
+
+/**
  * Return the [team1, team2] matchup for the current rotation index.
  * @param {object} rotationState - Row from the rotation_state table
  * @returns {[string[], string[]] | null}
  */
 function getCurrentMatchup(rotationState) {
-  const { player_discord_ids, current_index } = rotationState;
-  const rotations = generateRotations(player_discord_ids);
-  if (rotations.length === 0) return null;
-  return rotations[current_index % rotations.length];
+  const ordered = getOrderedMatchups(rotationState);
+  if (ordered.length === 0) return null;
+  return ordered[rotationState.current_index % ordered.length];
 }
 
 /**
@@ -55,10 +67,28 @@ function getCurrentMatchup(rotationState) {
  * @returns {[string[], string[]] | null}
  */
 function getNextMatchup(rotationState) {
-  const { player_discord_ids, current_index } = rotationState;
-  const rotations = generateRotations(player_discord_ids);
-  if (rotations.length === 0) return null;
-  return rotations[(current_index + 1) % rotations.length];
+  const ordered = getOrderedMatchups(rotationState);
+  if (ordered.length === 0) return null;
+  return ordered[(rotationState.current_index + 1) % ordered.length];
+}
+
+/**
+ * Return up to `count` upcoming matchups starting from the current position.
+ * Each entry includes the matchup and its 1-based position number in the sequence.
+ * @param {object} rotationState - Row from the rotation_state table
+ * @param {number} count - Number of matchups to return (default 4)
+ * @returns {Array<{ matchup: [string[], string[]], position: number }>}
+ */
+function getPreviewMatchups(rotationState, count = 4) {
+  const ordered = getOrderedMatchups(rotationState);
+  if (ordered.length === 0) return [];
+  const total = ordered.length;
+  const result = [];
+  for (let i = 0; i < count; i++) {
+    const pos = (rotationState.current_index + i) % total;
+    result.push({ matchup: ordered[pos], position: pos + 1 });
+  }
+  return result;
 }
 
 /**
@@ -82,4 +112,12 @@ function formatMatchup(team1Ids, team2Ids, nameMap = {}) {
   return `**Team 1:** ${t1}\n**Team 2:** ${t2}`;
 }
 
-module.exports = { generateRotations, getCurrentMatchup, getNextMatchup, totalMatchups, formatMatchup };
+module.exports = {
+  generateRotations,
+  getOrderedMatchups,
+  getCurrentMatchup,
+  getNextMatchup,
+  getPreviewMatchups,
+  totalMatchups,
+  formatMatchup,
+};


### PR DESCRIPTION
- /opr rotation skip (admin): advances the rotation index by one without
  requiring a game report — useful for cancelled game nights or passing
  over a matchup.

- /opr rotation preview (everyone): shows the next 4 upcoming matchups
  starting from the current position, each labelled with their rotation
  number.

- /opr rotation reorder <from> <to> (admin): persistently moves a matchup
  from one position to another in the rotation list. Internally stores a
  `matchup_order` integer[] in rotation_state (new DB column applied via
  migration). The currently active matchup remains unchanged; current_index
  is updated to track it in the new order. Running /opr rotation setup
  clears any custom ordering and regenerates the natural rotation.

Updated utilities in src/utils/rotation.js:
  - getOrderedMatchups(): applies custom matchup_order if set
  - getPreviewMatchups(): returns N upcoming matchups with position numbers
  - getCurrentMatchup() / getNextMatchup() now use getOrderedMatchups()

Also updates schema.sql, README.md, and CLAUDE.md per project conventions.

https://claude.ai/code/session_01Ay1H3jm1XzKBhbKCAbvTDb